### PR TITLE
fix: 🐛 corregir la declaración de variable chat en setup_chat

### DIFF
--- a/app/services/twitch/chat/chat_handler.py
+++ b/app/services/twitch/chat/chat_handler.py
@@ -13,6 +13,7 @@ chunk_message = []
 chat = None
 
 async def setup_chat(twitch):
+    global chat
     chat = await Chat(twitch)
     chat.register_event(ChatEvent.READY, on_ready)
     chat.register_event(ChatEvent.MESSAGE, on_message)


### PR DESCRIPTION
This pull request includes a small change to the `app/services/twitch/chat/chat_handler.py` file. The change introduces the `global` keyword to declare the `chat` variable as global within the `setup_chat` function, ensuring the variable is accessible across the module.