### PR TITLE
Fix/3 fix bot account conection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Icon
 
 # Token files
 tokens.json
+bot_tokens.json
 
 # Thumbnails
 ._*

--- a/app/main.py
+++ b/app/main.py
@@ -20,19 +20,19 @@ app.add_middleware(
 def read_root():
     return {"message": "Sandy IA corriendo🚀"}
 
-def run_bot_thread():
+def run_bot_thread(bot: bool):
     loop = asyncio.new_event_loop() 
     asyncio.set_event_loop(loop)
-    loop.run_until_complete(run_bot()) 
+    loop.run_until_complete(run_bot(bot)) 
 
 def transcribir_audio_thread():
     transcribir_audio()
 
 
 @app.get("/start")
-async def start_services():
+async def start_services(bot: bool = False):
     try:
-        threading.Thread(target=run_bot_thread, daemon=True).start()
+        threading.Thread(target=run_bot_thread, args=(bot,), daemon=True).start()
         threading.Thread(target=transcribir_audio_thread, daemon=True).start()
         return {"message": "Servicios iniciados"}
     except Exception as e:

--- a/app/services/twitch/chat/chat_handler.py
+++ b/app/services/twitch/chat/chat_handler.py
@@ -25,6 +25,7 @@ async def on_ready(ready_event: EventData):
 
 
 async def on_message(msg: ChatMessage):
+    print(f"Mensaje recibido: {msg.room.name}")
     print(f"{msg.user.name}: {msg.text}")
     if check_banned_words(msg.text) and msg.user.mod is False:
         response = check_message(msg.text)

--- a/app/services/twitch/events/moderation_handler.py
+++ b/app/services/twitch/events/moderation_handler.py
@@ -1,4 +1,5 @@
 from app.services.twitch.auth.auth import twitch,user
+from app.services.twitch.chat.chat_handler import chat
 import json
 
 async def moderator_actions(title: str, name: str):
@@ -19,10 +20,9 @@ async def moderator_actions(title: str, name: str):
          case "slow":
             await slow_mode(title)
          case _:
-            await twitch.send_chat_message(
-               broadcaster_id=user.id,
-               sender_id=user.id,
-               message=f"POLICE No se ha podido ejecutar la orden POLICE "
+            await chat.send_message(
+               room=user.display_name,
+               text=f"POLICE No se ha podido ejecutar la orden POLICE "
             )
             return False
    except Exception as e:
@@ -31,10 +31,9 @@ async def moderator_actions(title: str, name: str):
 
 async def change_title(title: str):
    await twitch.modify_channel_information(user.id, title=title)
-   await twitch.send_chat_message(
-      broadcaster_id=user.id,
-      sender_id=user.id,
-      message=f"POLICE Se ha cambiado el titulo del stream a {title} POLICE "
+   await chat.send_message(
+      room=user.display_name,
+      text=f"POLICE Se ha cambiado el titulo del stream a {title} POLICE "
    )
    
 async def change_game(game: str):
@@ -43,82 +42,72 @@ async def change_game(game: str):
       game_id = g.id
       break 
    await twitch.modify_channel_information(user.id, game_id)
-   await twitch.send_chat_message(
-      broadcaster_id=user.id,
-      sender_id=user.id,
-      message=f"POLICE Se ha cambiado la categoria del stream a {game} POLICE "
+   await chat.send_message(
+      room=user.display_name,
+      text=f"POLICE Se ha cambiado la categoria del stream a {game} POLICE "
    )
 
 async def create_clip():
    clip = await twitch.create_clip(user.id)
-   await twitch.send_chat_message(
-      broadcaster_id=user.id,
-      sender_id=user.id,
-      message=f"POLICE Se ha creado un clip {clip.edit_url} POLICE "
+   await chat.send_message(
+      room=user.display_name,
+      text=f"POLICE Se ha creado un clip {clip.edit_url} POLICE "
    )
 
 async def only_followers(activate:str):
    if activate=='on':
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,follower_mode=True)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha activado el modo seguidores POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha activado el modo seguidores POLICE "
       )
    else:
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,follower_mode=False)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha desactivado el modo seguidores POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha desactivado el modo seguidores POLICE "
       )
 
 async def only_subs(activate:str):
    if activate=='on':
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,subscriber_mode=True)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha activado el modo subs POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha activado el modo subs POLICE "
       )
    else:
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,subscriber_mode=False)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha desactivado el modo subs POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha desactivado el modo subs POLICE "
       )
 
 async def only_emotes(activate:str):
    if activate=='on':
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,emote_mode=True)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha activado el modo emotes POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha activado el modo emotes POLICE "
       )
    else:
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,emote_mode=False)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha desactivado el modo emotes POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha desactivado el modo emotes POLICE "
       )
 
 async def slow_mode(activate:str):
    if activate=='on':
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,slow_mode=True)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha activado el modo lento POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha activado el modo lento POLICE "
       )
    else:
       await twitch.update_chat_settings(broadcaster_id=user.id, moderator_id=user.id,slow_mode=False)
-      await twitch.send_chat_message(
-         broadcaster_id=user.id,
-         sender_id=user.id,
-         message=f"POLICE Se ha desactivado el modo lento POLICE "
+      await chat.send_message(
+         room=user.display_name,
+         text=f"POLICE Se ha desactivado el modo lento POLICE "
       )
       
 async def get_stream_info():

--- a/app/services/twitch/twitch.py
+++ b/app/services/twitch/twitch.py
@@ -2,8 +2,11 @@ import app.services.twitch.auth.auth as auth
 from app.services.twitch.chat.chat_handler import setup_chat
 from app.services.twitch.events.eventsub_handler import setup_eventsub
 
-async def run_bot():
-    twitch, user_id = await auth.create_twitch_instance()
-    await setup_chat(twitch)
+async def run_bot(bot: bool = False):
+    twitch,twitch_bot, user_id = await auth.create_twitch_instance(bot)
+    if bot:    
+        await setup_chat(twitch_bot)
+    else:
+        await setup_chat(twitch)
     await setup_eventsub(twitch, user_id)
 


### PR DESCRIPTION
This pull request introduces functionality to support a bot account alongside the primary Twitch account, refactors authentication and chat handling to accommodate this, and improves code clarity and maintainability. The most significant changes include adding support for bot-specific tokens, updating chat message handling to use the `chat` object, and modifying the `run_bot` function to optionally initialize the bot account.

### Bot account support:

* Introduced `BOT_TOKEN_FILE` and added methods `load_bot_tokens` and `save_bot_tokens` in `app/services/twitch/auth/auth.py` to manage bot-specific authentication tokens. [[1]](diffhunk://#diff-a07be03d784a78383c5d98efb2db85e82a7c3682e4006a33e49a0f873bc7055dR10) [[2]](diffhunk://#diff-a07be03d784a78383c5d98efb2db85e82a7c3682e4006a33e49a0f873bc7055dR49-R69)
* Updated `create_twitch_instance` to initialize a separate Twitch client for the bot account, authenticate it, and return both the primary and bot clients.

### Chat message handling refactor:

* Replaced direct calls to `twitch.send_chat_message` with `chat.send_message` for better encapsulation and to use the `chat` object for sending messages. This change was applied across multiple moderation actions in `app/services/twitch/events/moderation_handler.py`. [[1]](diffhunk://#diff-8f84b4f04d5def6654545ee35dd085c80684be174538e26c4a0c2e9b78d7a6fcL22-R25) [[2]](diffhunk://#diff-8f84b4f04d5def6654545ee35dd085c80684be174538e26c4a0c2e9b78d7a6fcL34-R36) [[3]](diffhunk://#diff-8f84b4f04d5def6654545ee35dd085c80684be174538e26c4a0c2e9b78d7a6fcL46-R110)

### Improvements to bot initialization:

* Modified `run_bot` in `app/services/twitch/twitch.py` to accept a `bot` parameter, allowing the setup of either the primary or bot account's chat and event subscriptions.
* Updated `start_services` and `run_bot_thread` in `app/main.py` to pass the `bot` parameter to properly initialize the bot account when requested.

### Debugging and logging:

* Added a debug print statement in `on_message` in `app/services/twitch/chat/chat_handler.py` to log the room name along with the message details.